### PR TITLE
Allow more than 10 multiple progress bars

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ var exports = module.exports = function (c) {
         var bar = new Bar(charm, x, y, params);
         multi.bars.push(bar);
         bar.offset = multi.offset;
+        
+        charm.setMaxListeners(multi.bars.length);
+        
         multi.on('offset', function (o) {
             bar.offset = o;
         });


### PR DESCRIPTION
`charm` will throw a warning if more than 10 bars are created simultaneously (repeated calls to `EventEmitter.on`).

By ensuring we call `charm.setMaxListeners` with the number of expected bars, this warning will not be thrown.